### PR TITLE
Support basic arithmetic

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "tailwindcss": "^4.1.12",
       },
       "devDependencies": {
+        "@types/bun": "^1.2.23",
         "@types/node": "^24.3.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
@@ -263,6 +264,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.2.23", "", { "dependencies": { "bun-types": "1.2.23" } }, "sha512-le8ueOY5b6VKYf19xT3McVbXqLqmxzPXHsQT/q9JHgikJ2X22wyTW3g3ohz2ZMnp7dod6aduIiq8A14Xyimm0A=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -370,6 +373,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.25.4", "", { "dependencies": { "caniuse-lite": "^1.0.30001737", "electron-to-chromium": "^1.5.211", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg=="],
+
+    "bun-types": ["bun-types@1.2.23", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-R9f0hKAZXgFU3mlrA0YpE/fiDvwV0FT9rORApt2aQVWSuJDzZOyB5QLc0N/4HF57CS8IXJ6+L5E4W1bW6NS2Aw=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "tailwindcss": "^4.1.12"
   },
   "devDependencies": {
+    "@types/bun": "^1.2.23",
     "@types/node": "^24.3.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",

--- a/src/lib/calculator.ts
+++ b/src/lib/calculator.ts
@@ -1,54 +1,69 @@
-// src/lib/calculator.ts
+import nerdamer from 'nerdamer/all.min'
 
 // Minimal ambient module so TS doesn't complain about missing nerdamer types.
 declare module 'nerdamer/all.min' {
-    const nerdamer: any;
-    export default nerdamer;
-  }
-  
-  import nerdamer from 'nerdamer/all.min';
-  
-  export type Env = Record<string, number>;
-  
-  export type CalcResult<T> =
-    | { ok: true; value: T }
-    | { ok: false; error: string };
-  
-  function ok<T>(value: T): CalcResult<T> {
-    return { ok: true, value };
-  }
-  function err(error: string): CalcResult<never> {
-    return { ok: false, error };
-  }
-  
-  /**
-   * Evaluate a numeric arithmetic expression with an optional variable map.
-   * Returns { ok: true, value } on success; { ok: false, error } on failure.
-   */
-  export function evaluateNumeric(src: string, env: Env = {}): CalcResult<number> {
-    try {
-      // nerdamer(...).evaluate(env).text() -> string like "14" or "1.75"
-      const textResult = nerdamer(src).evaluate(env).text();
-      const num = Number(textResult);
-  
-      // Guard against NaN / Infinity
-      if (!Number.isFinite(num)) {
-        return err('Non-finite result');
-      }
-      return ok(num);
-    } catch (e: any) {
-      // Normalize any parse/eval error into a simple string
-      return err(String(e?.message ?? e));
+  export default nerdamer
+}
+
+export type Env = Record<string, number>
+
+export type CalcResult<T> =
+    | { ok: true, value: T }
+    | { ok: false, error: string }
+
+/**
+ * Wraps a successful computation result into a CalcResult.
+ * @template T - Type of the successful value.
+ * @param   {T}             value - The computed value.
+ * @returns {CalcResult<T>}       An object containing the value with ok=true.
+ */
+function ok<T> (value: T): CalcResult<T> {
+  return { ok: true, value }
+}
+
+/**
+ * Wraps an error message into a CalcResult.
+ * @param   {string}            error - A description of the error that occurred.
+ * @returns {CalcResult<never>}       An object containing the error with ok=false.
+ */
+function err (error: string): CalcResult<never> {
+  return { ok: false, error }
+}
+
+/**
+ * Attempts to parse and evaluate a numeric expression using nerdamer.
+ * @param   {string}             src - The expression to evaluate (e.g. "2+3*4").
+ * @param   {Env}                env - The evaluation environment.
+ * @returns {CalcResult<number>}
+ *                                   - ok=true and a finite numeric value if evaluation succeeds,
+ *                                   - ok=false and an error message if evaluation fails or produces NaN/Infinity.
+ */
+export function evaluateNumeric (src: string, env: Env = {}): CalcResult<number> {
+  try {
+    // nerdamer(...).evaluate(env).text() -> string like "14" or "1.75"
+    const textResult = nerdamer(src).evaluate(env).text()
+    const num = Number(textResult)
+
+    // Guard against NaN / Infinity
+    if (!Number.isFinite(num)) {
+      return err('Non-finite result')
     }
+    return ok(num)
+  } catch (e: any) {
+    // Normalize any parse/eval error into a simple string
+    return err(String(e?.message ?? e))
   }
-  
-  /**
-   * "Calculator" convenience that throws on error (nice for callers that prefer exceptions).
-   * Same semantics as evaluateNumeric, but returns a number or throws.
-   */
-  export function calculate(src: string, env?: Env): number {
-    const res = evaluateNumeric(src, env ?? {});
-    if (!res.ok) throw new Error(res.error);
-    return res.value;
-  }
-  
+}
+
+/**
+ * Evaluates a numeric expression and returns its value, throwing if evaluation fails.
+ * @param   {string} src   - The expression to evaluate (e.g. "10/2").
+ * @param   {Env}    [env] - An optional environment of variable bindings used in evaluation.
+ * @throws  {Error}        If evaluation fails or produces a non-finite result.
+ * @returns {number}       The evaluated numeric value.
+ */
+export function calculate (src: string, env?: Env): number {
+  const res = evaluateNumeric(src, env ?? {})
+  if (!res.ok) throw new Error(res.error)
+  return res.value
+}

--- a/src/test/calculator.test.ts
+++ b/src/test/calculator.test.ts
@@ -1,50 +1,50 @@
-import { test, expect } from "bun:test";
-import { evaluateNumeric } from "../lib/calculator";
+import { test, expect } from 'bun:test'
+import { evaluateNumeric } from '../lib/calculator'
 
-test("adds two positive numbers", () => {
-  const res = evaluateNumeric("2+3");
-  expect(res.ok).toBe(true);
-  if (res.ok) expect(res.value).toBe(5);
-});
+test('adds two positive numbers', () => {
+  const res = evaluateNumeric('2+3')
+  expect(res.ok).toBe(true)
+  if (res.ok) expect(res.value).toBe(5)
+})
 
-test("handles subtraction with negatives", () => {
-  const res = evaluateNumeric("-7-3");
-  expect(res.ok).toBe(true);
-  if (res.ok) expect(res.value).toBe(-10);
-});
+test('handles subtraction with negatives', () => {
+  const res = evaluateNumeric('-7-3')
+  expect(res.ok).toBe(true)
+  if (res.ok) expect(res.value).toBe(-10)
+})
 
-test("handles multiplication", () => {
-  const res = evaluateNumeric("4*5");
-  expect(res.ok).toBe(true);
-  if (res.ok) expect(res.value).toBe(20);
-});
+test('handles multiplication', () => {
+  const res = evaluateNumeric('4*5')
+  expect(res.ok).toBe(true)
+  if (res.ok) expect(res.value).toBe(20)
+})
 
-test("handles division", () => {
-  const res = evaluateNumeric("20/4");
-  expect(res.ok).toBe(true);
-  if (res.ok) expect(res.value).toBe(5);
-});
+test('handles division', () => {
+  const res = evaluateNumeric('20/4')
+  expect(res.ok).toBe(true)
+  if (res.ok) expect(res.value).toBe(5)
+})
 
-test("respects PEMDAS order of operations", () => {
-  const res = evaluateNumeric("2 + 3 * 4");
-  expect(res.ok).toBe(true);
-  if (res.ok) expect(res.value).toBe(14); // 2 + (3*4)
-});
+test('respects PEMDAS order of operations', () => {
+  const res = evaluateNumeric('2 + 3 * 4')
+  expect(res.ok).toBe(true)
+  if (res.ok) expect(res.value).toBe(14)
+})
 
-test("handles parentheses overriding precedence", () => {
-  const res = evaluateNumeric("(2 + 3) * 4");
-  expect(res.ok).toBe(true);
-  if (res.ok) expect(res.value).toBe(20);
-});
+test('handles parentheses overriding precedence', () => {
+  const res = evaluateNumeric('(2 + 3) * 4')
+  expect(res.ok).toBe(true)
+  if (res.ok) expect(res.value).toBe(20)
+})
 
-test("handles nested parentheses", () => {
-  const res = evaluateNumeric("((1 + 2) * (3 + 4))");
-  expect(res.ok).toBe(true);
-  if (res.ok) expect(res.value).toBe(21);
-});
+test('handles nested parentheses', () => {
+  const res = evaluateNumeric('((1 + 2) * (3 + 4))')
+  expect(res.ok).toBe(true)
+  if (res.ok) expect(res.value).toBe(21)
+})
 
-test("handles decimal numbers", () => {
-  const res = evaluateNumeric("0.5 + 1.25");
-  expect(res.ok).toBe(true);
-  if (res.ok) expect(res.value).toBeCloseTo(1.75);
-});
+test('handles decimal numbers', () => {
+  const res = evaluateNumeric('0.5 + 1.25')
+  expect(res.ok).toBe(true)
+  if (res.ok) expect(res.value).toBeCloseTo(1.75)
+})


### PR DESCRIPTION
Closes #4

I have written the calculator to use an existing package to support all basic arithmetic.

Still need to deal with Node value inputting and need to figure out where implicit edge handing happens but that will be next sprint. This one should support all basic arithmetic. I will add tests for next sprint issues later.