### PR TITLE
Use `createdAt` instead of `lastModified` for primary deps

### DIFF
--- a/src/components/HistoryTree/VisualNode.tsx
+++ b/src/components/HistoryTree/VisualNode.tsx
@@ -23,7 +23,7 @@ function isPrimaryDependency (dependency: TreeNode, dependent: TreeNode): boolea
       continue
     }
 
-    if (dep.lastModified > mostRecent.lastModified) mostRecent = dep
+    if (dep.createdAt > mostRecent.createdAt) mostRecent = dep
   }
 
   return dependency === mostRecent

--- a/src/lib/calculator.ts
+++ b/src/lib/calculator.ts
@@ -162,7 +162,6 @@ export class HistoryCalculator {
 
     node.rawUserEquation = equation
     node.parsedEquation = parsed
-    node.lastModified = new Date()
     const value = this.refreshNode(node)
     this.tree.dispatchEvent(new CustomEvent('mutate'))
     return [parsed, value, node.dependencies]

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -11,7 +11,7 @@ export interface SerializedNode {
   rawUserEquation: string
   parsed: Expression
   note?: string
-  lastModified: Date
+  createdAt: Date
 }
 
 export interface SerializedTree {
@@ -93,7 +93,7 @@ export class Tree extends EventTarget {
       this.idLookup.set(node.id, node)
       if (serializedNode.alias) this.setAlias(node, serializedNode.alias)
       if (serializedNode.note) this.setNote(node, serializedNode.note)
-      node.lastModified = new Date(serializedNode.lastModified)
+      node.createdAt = new Date(serializedNode.createdAt)
     }
 
     for (const serializedNode of serialized.nodes) {
@@ -148,10 +148,8 @@ export class Tree extends EventTarget {
 
     let node: TreeNode
     if (dependencies.length) {
-      // If this is a descendant of more than one node, use a new letter
-      const letterConstraint = dependencies.length > 1
-        ? undefined
-        : dependencies[0]!.id.match(/^[a-z]+/)![0]
+      const primary = dependencies.reduce((a, d) => d.createdAt > a.createdAt ? d : a)
+      const letterConstraint = primary.id.match(/^[a-z]+/)![0]
 
       const id = this.generateID(letterConstraint)
       node = new TreeNode(id, rawUserEquation, parsedEquation)
@@ -296,7 +294,7 @@ class TreeNode {
   /** An externally controllled amortized value */
   amortizedValue?: BoxedExpression
   note?: string
-  lastModified: Date
+  createdAt: Date
 
   /**
    * Construct a node
@@ -308,7 +306,7 @@ class TreeNode {
     this.id = id
     this.rawUserEquation = rawUserEquation
     this.parsedEquation = parsedEquation
-    this.lastModified = new Date()
+    this.createdAt = new Date()
   }
 
   /**
@@ -323,7 +321,7 @@ class TreeNode {
       rawUserEquation: this.rawUserEquation,
       parsed: this.parsedEquation.toJSON(),
       note: this.note,
-      lastModified: this.lastModified
+      createdAt: this.createdAt
     }
   }
 }


### PR DESCRIPTION
- Use `createdAt` instead of `lastModified` for primary deps so that the tree doesn't shift around on edits
- ID letter now always inherited from primary dependency (no longer a new letter for a descendant of multiple nodes)